### PR TITLE
fix flaky test eu.xenit.alfred.initializr.generator.docker.compose.DockerComposeYmlWriterDelegateTest.testVolumes

### DIFF
--- a/initializr-generator/src/main/java/eu/xenit/alfred/initializr/generator/docker/compose/DockerComposeYmlWriterDelegate.java
+++ b/initializr-generator/src/main/java/eu/xenit/alfred/initializr/generator/docker/compose/DockerComposeYmlWriterDelegate.java
@@ -7,6 +7,7 @@ import eu.xenit.alfred.initializr.generator.docker.compose.model.ComposeVolumes;
 import eu.xenit.alfred.initializr.generator.docker.compose.model.DockerComposeModel;
 import io.spring.initializr.generator.io.IndentingWriter;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -40,7 +41,7 @@ public class DockerComposeYmlWriterDelegate {
 
         writer.println();
         writer.println("volumes:");
-        writer.indented(() -> volumes.stream().forEach(vol -> writeVolume(writer, vol)));
+        writer.indented(() -> volumes.stream().sorted(Comparator.comparing(ComposeVolumeInfo::getName)).forEach(vol -> writeVolume(writer, vol)));
     }
 
     private void writeVolume(IndentingWriter writer, ComposeVolumeInfo vol) {


### PR DESCRIPTION
## Problem

The test `eu.xenit.alfred.initializr.generator.docker.compose.DockerComposeYmlWriterDelegateTest.testVolumes` asserts the configuration of the DockerComposeModel. This configuration is returned using the YML Schema. But the order, in which the two given values (`alfresco` and  `postgres`) are returned by the map and further by the stream, is not deterministic. The test expects the values to be in certain order. 
This results in a flaky test. 

https://github.com/hofi1/start.xenit.eu/blob/4d4a8881a0f54337c7583e80f162ebe4a5c916b0/initializr-generator/src/main/java/eu/xenit/alfred/initializr/generator/docker/compose/DockerComposeYmlWriterDelegate.java#L43

This problem was found by the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Engine.

## Solution
Sort the stream, to make sure, it is returned in predefined order. 

https://github.com/hofi1/start.xenit.eu/blob/fbbee8405e74c288e61ecc1fbd11895cbc22e132/initializr-generator/src/main/java/eu/xenit/alfred/initializr/generator/docker/compose/DockerComposeYmlWriterDelegate.java#L44


## Reproduce
To reproduce follow the steps:

1. `./gradlew build -x test`
2. Add the following text to the top of the build.gradle file in $PROJ_DIR.
```shell
buildscript {
    repositories {
      maven {
        url = uri('https://plugins.gradle.org/m2/')
      }
    }
    dependencies {
      classpath('edu.illinois:plugin:2.1.1')
    }
}
``` 
3. Add the following line to the end of the build.gradle file in $PROJ_DIR.
```shell
apply plugin: 'edu.illinois.nondex'
``` 
4. Add the following to the end of the build.gradle file in $PROJ_DIR.
```shell
subprojects {
  apply plugin: 'edu.illinois.nondex'
}
```
5. Run
```shell
./gradlew --info nondexTest --tests=eu.xenit.alfred.initializr.generator.docker.compose.DockerComposeYmlWriterDelegateTest.testVolumes --nondexRuns=100 -p start.xenit.eu
``` 